### PR TITLE
Drag and drop improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,18 @@ function createElementPropertyRecord(
     virtualValue: currentValue,
     mutations: [],
     el,
+    _positionTimeout: null,
     observer: new MutationObserver(() => {
+      // enact a 1 second timeout that blocks subsequent firing of the
+      // observer until the timeout is complete. This will prevent multiple
+      // mutations from firing in quick succession, which can cause the
+      // mutation to be reverted before the DOM has a chance to update.
+      if (attr === 'position' && record._positionTimeout) return;
+      else if (attr === 'position')
+        record._positionTimeout = setTimeout(() => {
+          record._positionTimeout = null;
+        }, 1000);
+
       const currentValue = getCurrentValue(el);
       if (
         attr === 'position' &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,22 +303,17 @@ function stopMutating(mutation: Mutation, el: Element) {
 
 // maintain list of elements associated with mutation
 function refreshElementsSet(mutation: Mutation) {
+  // if a position mutation has already found an element to move, don't move
+  // any more elements
+  if (mutation.kind === 'position' && mutation.elements.size === 1) return;
+
   const existingElements = new Set(mutation.elements);
-  const newElements: Set<Element> = new Set();
   const matchingElements = document.querySelectorAll(mutation.selector);
 
   matchingElements.forEach(el => {
-    newElements.add(el);
     if (!existingElements.has(el)) {
       mutation.elements.add(el);
       startMutating(mutation, el);
-    }
-  });
-
-  existingElements.forEach(el => {
-    if (!newElements.has(el)) {
-      mutation.elements.delete(el);
-      stopMutating(mutation, el);
     }
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -183,13 +183,8 @@ const setElementPosition = (el: Element, value: ElementPositionWithDomNode) => {
     value.insertBeforeNode &&
     !value.parentNode.contains(value.insertBeforeNode)
   ) {
-    console.error(
-      'position mutation skipped - insertBeforeNode not a child of parent',
-      {
-        el,
-        ...value,
-      }
-    );
+    // skip position mutation - insertBeforeNode not a child of parent. happens
+    // when mutation observer for indvidual element fires out of order
     return;
   }
   value.parentNode.insertBefore(el, value.insertBeforeNode);

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,11 +89,11 @@ function queueIfNeeded(
       val.insertBeforeNode !== currentVal.insertBeforeNode
     ) {
       record.isDirty = true;
-      queueDOMUpdates();
+      runDOMUpdates();
     }
   } else if (val !== currentVal) {
     record.isDirty = true;
-    queueDOMUpdates();
+    runDOMUpdates();
   }
 }
 
@@ -260,8 +260,6 @@ function setPropertyValue<T extends ElementPropertyRecord<any, any>>(
   m.setValue(el, val);
 }
 
-let raf = false;
-
 function setValue(m: ElementRecord, el: Element) {
   m.html && setPropertyValue<HTMLRecord>(el, 'html', m.html);
   m.classes && setPropertyValue<ClassnameRecord>(el, 'class', m.classes);
@@ -270,15 +268,9 @@ function setValue(m: ElementRecord, el: Element) {
     setPropertyValue<AttributeRecord>(el, attr, m.attributes[attr]);
   });
 }
-function setValues() {
-  raf = false;
+
+function runDOMUpdates() {
   elements.forEach(setValue);
-}
-function queueDOMUpdates() {
-  if (!raf) {
-    raf = true;
-    requestAnimationFrame(setValues);
-  }
 }
 
 // find or create ElementPropertyRecord, add mutation to it, then run

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,19 @@ const getElementPosition = (el: Element): ElementPositionWithDomNode => {
   };
 };
 const setElementPosition = (el: Element, value: ElementPositionWithDomNode) => {
+  if (
+    value.insertBeforeNode &&
+    !value.parentNode.contains(value.insertBeforeNode)
+  ) {
+    console.error(
+      'position mutation skipped - insertBeforeNode not a child of parent',
+      {
+        el,
+        ...value,
+      }
+    );
+    return;
+  }
   value.parentNode.insertBefore(el, value.insertBeforeNode);
 };
 function getElementPositionRecord(element: Element): PositionRecord {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,12 @@ function createElementPropertyRecord(
     el,
     observer: new MutationObserver(() => {
       const currentValue = getCurrentValue(el);
+      if (
+        attr === 'position' &&
+        currentValue.parentNode === record.virtualValue.parentNode &&
+        currentValue.insertBeforeNode === record.virtualValue.insertBeforeNode
+      )
+        return;
       if (currentValue === record.virtualValue) return;
       record.originalValue = currentValue;
       mutationRunner(record);
@@ -57,7 +63,16 @@ function createElementPropertyRecord(
     setValue,
     getCurrentValue,
   };
-  record.observer.observe(el, getObserverInit(attr));
+  if (attr === 'position' && el.parentNode) {
+    record.observer.observe(el.parentNode, {
+      childList: true,
+      subtree: true,
+      attributes: false,
+      characterData: false,
+    });
+  } else {
+    record.observer.observe(el, getObserverInit(attr));
+  }
   return record;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ type Mutation =
 type MutationKind = Mutation['kind'];
 
 interface ElementPropertyRecord<T, V> {
+  _positionTimeout: NodeJS.Timeout | number | null;
   observer: MutationObserver;
   originalValue: V;
   virtualValue: V;


### PR DESCRIPTION
A list of improvements to the dom-mutator to make drag-and-drop more predictable, and make all mutations more deterministic when ran.

Changes:
- Make `position` mutations operate on only the first found element
- Remove `stopMutation` 'clean-up' step from `refreshElementsSet`
- Refine mutation-specific `MutationObserver`s for `'position'` mutations
  - We now attach mutation observer to parent node and watch for `childList` changes
  - Prevent looping by 'throttling' mutation observer handler with lock-out flag
- Remove RAF approach ('queuing updates') for direct synchronous manipulation of DOM elements